### PR TITLE
add actions to schedule2 for Workflow Jobs

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
@@ -196,7 +196,11 @@ public final class EventListener implements GerritEventListener {
             // TODO: Using SCMTriggerItem smells bad here. What should we be using?
             // BuildableItem seems like the more correct interface to use, but it's scheduleBuild methods don't give
             // access to the Future.
-            build = ((SCMTriggerItem)project).scheduleBuild2(projectbuildDelay);
+            build = ((SCMTriggerItem)project).scheduleBuild2(projectbuildDelay,
+                                                             badgeAction,
+                                                             new RetriggerAction(cause.getContext()),
+                                                             new RetriggerAllAction(cause.getContext()),
+                                                             parameters);
         } else {
             throw new IllegalStateException("Unexpected error. Unsupported Job type for Gerrit Trigger: "
                     + project.getClass().getName());


### PR DESCRIPTION
Add the badgeAction, RetriggerActions, and paramter actions for the
Workflow Job. It may be worth just using straight up SCMTrigger
interface for both workflow and abstract projects, as this interface is
supported by both, however this patch does not make this change, as we
lose the ability to pause the Cause directly into the AbstractProject's
ScheduleBuild2 function.

Signed-off-by: Jacob Keller jacob.keller@gmail.com
